### PR TITLE
Remove extraneous imports

### DIFF
--- a/notebooks/denoising-correlations-ecg.ipynb
+++ b/notebooks/denoising-correlations-ecg.ipynb
@@ -12,29 +12,7 @@
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import scipy.signal as signal\n",
-    "import sklearn\n",
-    "import os\n",
-    "from sklearn.metrics import normalized_mutual_info_score, pairwise_distances\n",
-    "from scipy.stats import spearmanr"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "numpy, v. 1.19.0\n",
-      "sklearn, v. 0.23.1\n"
-     ]
-    }
-   ],
-   "source": [
-    "print('numpy, v.', np.__version__)\n",
-    "print('sklearn, v.', sklearn.__version__)"
+    "import os"
    ]
   },
   {

--- a/notebooks/denoising-correlations-eda.ipynb
+++ b/notebooks/denoising-correlations-eda.ipynb
@@ -12,29 +12,7 @@
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import scipy.signal as signal\n",
-    "import sklearn\n",
-    "import os\n",
-    "from sklearn.metrics import normalized_mutual_info_score, pairwise_distances\n",
-    "from scipy.stats import spearmanr"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "numpy, v. 1.19.0\n",
-      "sklearn, v. 0.23.1\n"
-     ]
-    }
-   ],
-   "source": [
-    "print('numpy, v.', np.__version__)\n",
-    "print('sklearn, v.', sklearn.__version__)"
+    "import os"
    ]
   },
   {

--- a/notebooks/denoising_ecg.ipynb
+++ b/notebooks/denoising_ecg.ipynb
@@ -19,14 +19,11 @@
     "import pandas as pd\n",
     "import seaborn as sns\n",
     "import matplotlib.pyplot as plt\n",
-    "import bioread as br\n",
     "from matplotlib.ticker import FormatStrFormatter\n",
     "\n",
     "\n",
     "from glob import glob\n",
-    "import scipy.signal as signal\n",
-    "from sklearn.metrics import normalized_mutual_info_score, pairwise_distances, pairwise_distances_chunked\n",
-    "#from tslearn.metrics import dtw"
+    "import scipy.signal as signal"
    ]
   },
   {
@@ -57,8 +54,6 @@
     "import pandas\n",
     "print('Pandas version', pandas.__version__)\n",
     "\n",
-    "import bioread\n",
-    "print('bioread version', bioread.__version__)\n",
     "\n",
     "import sys \n",
     "print(\"Python version\", sys.version) "

--- a/notebooks/denoising_eda.ipynb
+++ b/notebooks/denoising_eda.ipynb
@@ -19,14 +19,11 @@
     "import pandas as pd\n",
     "import seaborn as sns\n",
     "import matplotlib.pyplot as plt\n",
-    "import bioread as br\n",
     "from matplotlib.ticker import FormatStrFormatter\n",
     "\n",
     "\n",
     "from glob import glob\n",
-    "import scipy.signal as signal\n",
-    "from sklearn.metrics import normalized_mutual_info_score, pairwise_distances, pairwise_distances_chunked\n",
-    "#from tslearn.metrics import dtw"
+    "import scipy.signal as signal"
    ]
   },
   {
@@ -56,9 +53,6 @@
     "\n",
     "import pandas\n",
     "print('Pandas version', pandas.__version__)\n",
-    "\n",
-    "import bioread\n",
-    "print('bioread version', bioread.__version__)\n",
     "\n",
     "import sys \n",
     "print(\"Python version\", sys.version) "


### PR DESCRIPTION
Notebooks were still importing `sklearn` and `bioread`, which are unnecessary and not in the Binder install requirements.