### PR TITLE
Fix notch frequency calculation in filtering.py

### DIFF
--- a/filtering.py
+++ b/filtering.py
@@ -40,7 +40,7 @@ def comb_band_stop(notch, filtered, Q, fs):
     j = 1
     while (notch / j) > 1:
         #print(notch * i)
-        f0 = notch / i
+        f0 = notch / j
         w0 = f0/nyquist
         b,a = signal.iirnotch(w0, Q)
         filtered = signal.filtfilt(b, a, filtered)


### PR DESCRIPTION
Hello! Thank you so much for making your code available, Katie. I've found it super helpful in denoising ECG data collected during multi-band fMRI and I'll be happy to cite your paper (Bottenhorn et al., 2023) when the time comes to write up what we're working on. 

Today I noticed (actually, Google Gemini 3.1 Pro noticed) that the while loop starting on line 41 in the comb_band_stop() function referenced i instead of j in the denominator when calculating f0 (line 43). Referencing j in the denominator would ensure that the filter steps through the sub-harmonics. But maybe you intended for i to be referenced in the denominator and I simply don't understand the rationale!

Also, this is my first pull request ever-- apologies if I'm breaking etiquette somehow.

Cheers and thanks again,

Heather  